### PR TITLE
Nested Animations example (incomplete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,10 @@ invoked multiple times to animate between values. Making reusable functions
 that use this widget and also take a generic element might be difficult. This
 particular problem might be better solved by a new widget in a future version
 that keeps the animated value in the app state rather than within the widget.
+
+Nested animations also don't work completely as expected yet if both properties
+are actively being animated. One animation at a time will function correctly,
+but trying to adjust both at the same time leads to the inner property skipping
+to the final value. This is demonstrated in the `nested_animations` example.
+That being said, you can always pass a tuple to an animation builder if both
+properties are being used in the same view.

--- a/animation_builder/src/animation_builder.rs
+++ b/animation_builder/src/animation_builder.rs
@@ -225,11 +225,6 @@ where
 
         // Request a redraw if the spring has remaining energy
         if spring.has_energy() {
-            println!(
-                "{} redrawing after {}ms",
-                std::any::type_name::<T>(),
-                now.duration_since(spring.last_update()).as_millis(),
-            );
             shell.request_redraw(iced::window::RedrawRequest::NextFrame);
             // Only invalidate the layout if the user indicates to do so
             if self.animates_layout {
@@ -237,7 +232,6 @@ where
             }
 
             // Update the animation and request a redraw
-            println!("Redrawing {:?} at {:?}", std::any::type_name::<T>(), now);
             spring.update(now);
             self.cached_element = (self.builder)(spring.value().clone());
         }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,3 +37,7 @@ path = "preview_motion.rs"
 [[example]]
 name = "animated_drawer"
 path = "animated_drawer.rs"
+
+[[example]]
+name = "nested_animations"
+path = "nested_animations.rs"

--- a/examples/derived_animation.rs
+++ b/examples/derived_animation.rs
@@ -6,7 +6,7 @@ use iced_anim::Animate;
 use iced_anim::AnimationBuilder;
 
 /// A custom struct with all animatable properties that derives `Animate`
-#[derive(Animate, Clone, PartialEq)]
+#[derive(Animate, Clone, Debug, PartialEq)]
 struct CustomRect {
     width: f32,
     height: f32,

--- a/examples/nested_animations.rs
+++ b/examples/nested_animations.rs
@@ -1,0 +1,81 @@
+use iced::{
+    widget::{button, column, container, row, text},
+    Border, Color, Element, Length,
+};
+use iced_anim::animation_builder::AnimationBuilder;
+
+#[derive(Debug, Clone)]
+enum Message {
+    AdjustAll,
+    AdjustSize,
+    AdjustColor,
+}
+
+struct State {
+    size: f32,
+    color: Color,
+}
+
+const CYAN: Color = Color::from_rgb(0.0, 0.8, 0.8);
+const MAGENTA: Color = Color::from_rgb(1.0, 0.0, 1.0);
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            size: 50.0,
+            color: CYAN,
+        }
+    }
+}
+
+impl State {
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::AdjustAll => {
+                self.size = if self.size == 50.0 { 150.0 } else { 50.0 };
+                self.color = if self.color == CYAN { MAGENTA } else { CYAN };
+            }
+            Message::AdjustSize => self.size = if self.size == 50.0 { 150.0 } else { 50.0 },
+            Message::AdjustColor => self.color = if self.color == CYAN { MAGENTA } else { CYAN },
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        let buttons = row![
+            button(text("Adjust size")).on_press(Message::AdjustSize),
+            button(text("Adjust color")).on_press(Message::AdjustColor),
+            button(text("Adjust all")).on_press(Message::AdjustAll),
+        ]
+        .spacing(8);
+
+        let animated_box = AnimationBuilder::new(self.size, |size| {
+            AnimationBuilder::new(self.color, move |color| {
+                container(text(size as isize))
+                    .style(move |_: &iced::Theme| container::Style {
+                        border: Border {
+                            color,
+                            width: 1.0,
+                            radius: 6.0.into(),
+                        },
+                        background: Some(color.into()),
+                        ..Default::default()
+                    })
+                    .center(size)
+                    .into()
+            })
+            .animates_layout(true)
+            .into()
+        })
+        .animates_layout(true);
+
+        column![buttons, animated_box]
+            .spacing(8)
+            .padding(8)
+            .width(Length::Shrink)
+            .into()
+    }
+}
+
+pub fn main() -> iced::Result {
+    iced::run("Nested AnimationBuilders", State::update, State::view)
+}

--- a/examples/nested_animations.rs
+++ b/examples/nested_animations.rs
@@ -1,3 +1,7 @@
+//! Note: this example doesn't yet fully work as expected. The core issue is needing to rebuild
+//! the `cached_element` in `AnimationBuilder::on_event`, but trying to propagate events to the
+//! updated widget causes a panic in the `preview_motion` example. This is related to the
+//! `push_maybe` calls in that example, although I haven't figured out a workaround yet.
 use iced::{
     widget::{button, column, container, row, text},
     Border, Color, Element, Length,


### PR DESCRIPTION
This PR adds a new `nested_animations` example to help future testing. Nested animations don't yet fully work due to how the `AnimationBuilder` has to update its `cached_element`, and attempting to propagate events to the updated cached element will cause a panic in the `preview_motion` example due to some conditional column and row additions. This example will help keep track of this issue as the widget is further developed.

The `Spring` struct also now stores the `last_update` instant directly instead of delegating it to the parent widget. This should make it easier to create custom widgets containing animated values since each widget will no longer need to track the `last_update` instant on its own.