### PR TITLE
Add state-driven animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ provides the current animated value and will be called to generate the next
 view as appropriate. To see more for this particular example, refer to the
 `animated_size` example.
 
+#### Limitations
+
+It might not be easy/possible to pass in non-clonable content like custom
+elements to `AnimationBuilder`'s closure to due the closure being having to be
+invoked multiple times to animate between values. Making reusable functions
+that use this widget and also take a generic element might be difficult.
+
+Nested animations also don't work if both properties are actively being 
+animated. One animation at a time will function correctly, but trying to adjust
+both at the same time leads to the inner property skipping to the final value.
+Use the `Animation` widget if you need any of these properties.
+
 ### `Animation` widget
 
 The `Animation` widget works by taking a `Spring<T>` value and some element,
@@ -47,7 +59,7 @@ then emitting a message when the value needs to change. Your app state and
 message would look something like this:
 
 ```rust
-use iced_anim::{Spring, Animation};
+use iced_anim::{Animation, Spring, SpringEvent};
 
 #[derive(Default)]
 struct State {
@@ -56,13 +68,13 @@ struct State {
 
 #[derive(Clone)]
 enum Message {
-    UpdateSize(std::time::Instant),
-    TargetSize(f32),
+    UpdateSize(SpringEvent<f32>),
 }
 ```
 
 Then, somewhere in your view, have a way to change the spring's target and
-update the animated value:
+update the animated value. You can use `.into()` as a shorthand to create a
+`SpringEvent::Target` for changing where the spring should animate towards.
 
 ```rust
 use iced::widget::{Column, button, text};
@@ -70,7 +82,7 @@ use iced::widget::{Column, button, text};
 Column::new()
     .push(
         button(text("+50"))
-            .on_press(Message::TargetSize(self.size.value() + 50.0))
+            .on_press(Message::UpdateSize((self.size.value() + 50.0).into()))
     )
     .push(
         Animation::new(self.size, text(self.size.value().to_string()))
@@ -78,22 +90,28 @@ Column::new()
     )
 ```
 
-Finally, your update function will call `self.size.set_target` to indicate the
-spring should animate towards a new target, and `self.size.update` to animate
-towards the new value.
+Finally, your update function will forward the event to `self.size.update` to 
+update the spring's inner state correctly. 
 
 ```rust
 impl State {
     fn update(&mut self, message: Message) {
         match message {
-            Message::UpdateSize(now) => self.size.update(now),
-            Message::TargetSize(new_size) => self.size.set_target(new_size),
+            Message::UpdateSize(event) => self.size.update(event),
         }
     }
 }
 ```
 
 See the `stateful_animation` example for a complete example.
+
+### Which one should I use?
+
+Generally, if you're animating a tiny value that might not be directly within
+your state and the element won't contain any nested animated values, then use
+`AnimationBuilder`. Otherwise, use the state-driven `Animation` to avoid the
+limitations of widget-driven animations. Also, use `Animation` anytime you want
+your state to contain the animated value.
 
 ## Types that implement `Animate`
 
@@ -149,19 +167,3 @@ AnimationBuilder::new(self.size, |size| {
 Refer to the `examples` directory for a variety of ways to use this crate.
 You can also run these examples locally with `cargo run --example <package>`,
 e.g. `cargo run --example animated_color`.
-
-## Limitations
-
-It might not be easy/possible to pass in non-clonable content like custom
-elements to `AnimationBuilder`'s closure to due the closure being having to be
-invoked multiple times to animate between values. Making reusable functions
-that use this widget and also take a generic element might be difficult. This
-particular problem might be better solved by a new widget in a future version
-that keeps the animated value in the app state rather than within the widget.
-
-Nested animations also don't work completely as expected yet if both properties
-are actively being animated. One animation at a time will function correctly,
-but trying to adjust both at the same time leads to the inner property skipping
-to the final value. This is demonstrated in the `nested_animations` example.
-That being said, you can always pass a tuple to an animation builder if both
-properties are being used in the same view.

--- a/animation_builder/src/animation.rs
+++ b/animation_builder/src/animation.rs
@@ -1,0 +1,241 @@
+//! A widget that helps you animate a value over time from your state.
+//!
+//! The main difference between this widget and the `AnimationBuilder` is that
+//! this widget allows you to directly change the value stored in your state
+//! versus passively animating a value. This may also compose better with other
+//! animations due to some limitations around widget-driven animations instead
+//! of state-driven animations. Refer to the `AnimationBuilder` docs for more
+//! details.
+//!
+//! # Example
+//! ```rust
+//! use iced::widget::{button, text, Row};
+//! use iced_anim::{Spring, Animation};
+//!
+//! #[derive(Default)]
+//! struct State {
+//!     size: Spring<f32>,
+//! }
+//!
+//! #[derive(Clone)]
+//! enum Message {
+//!     UpdateSize(std::time::Instant),
+//!     TargetSize(f32),
+//! }
+//!
+//! impl State {
+//!     fn update(&mut self, message: Message) {
+//!         match message {
+//!             Message::UpdateSize(now) => self.size.update(now),
+//!             Message::TargetSize(size) => self.size.set_target(size),
+//!         }
+//!     }
+//!
+//!     fn view(&self) -> iced::Element<Message> {
+//!         Row::new()
+//!             .push(
+//!                 button(text("Change target"))
+//!                     .on_press(Message::TargetSize(self.size.value() + 50.0))
+//!             )
+//!             .push(
+//!                 Animation::new(&self.size, text(self.size.value().to_string()))
+//!                     .on_update(Message::UpdateSize)
+//!             )
+//!            .into()
+//!     }
+//! }
+//! ```
+use std::time::Instant;
+
+use iced::{
+    advanced::{widget::Tree, Widget},
+    Element,
+};
+
+use crate::{Animate, Spring};
+
+/// A widget that helps you animate a value over time from your state.
+/// This is useful for animating changes to a widget's appearance or layout
+/// where you want to directly change the value stored in your state versus
+/// passively animating a value like the `AnimationBuilder`.
+pub struct Animation<'a, T: Animate, Message, Theme, Renderer> {
+    /// The spring that controls the animated value.
+    spring: &'a Spring<T>,
+    /// The content that will respond to the animation.
+    content: Element<'a, Message, Theme, Renderer>,
+    /// The function that will be called when the spring needs to be updated.
+    on_update: Option<Box<dyn Fn(Instant) -> Message>>,
+}
+
+impl<'a, T, Message, Theme, Renderer> Animation<'a, T, Message, Theme, Renderer>
+where
+    T: 'static + Animate,
+    Message: 'a + Clone,
+{
+    /// Creates a new `Animation` with the given `spring` and `content`.
+    pub fn new(
+        spring: &'a Spring<T>,
+        content: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        Self {
+            spring,
+            content: content.into(),
+            on_update: None,
+        }
+    }
+
+    /// Sets the function that will be called when the spring needs to be updated.
+    pub fn on_update<F>(mut self, build_message: F) -> Self
+    where
+        F: Fn(Instant) -> Message + 'static,
+    {
+        self.on_update = Some(Box::new(build_message));
+        self
+    }
+}
+
+impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Animation<'a, T, Message, Theme, Renderer>
+where
+    T: 'static + Animate,
+    Message: 'a + Clone,
+    Renderer: 'a + iced::advanced::Renderer,
+{
+    fn size(&self) -> iced::Size<iced::Length> {
+        self.content.as_widget().size()
+    }
+
+    fn size_hint(&self) -> iced::Size<iced::Length> {
+        self.content.as_widget().size_hint()
+    }
+
+    fn children(&self) -> Vec<iced::advanced::widget::Tree> {
+        vec![Tree::new(&self.content)]
+    }
+
+    fn diff(&self, tree: &mut iced::advanced::widget::Tree) {
+        tree.diff_children(std::slice::from_ref(&self.content));
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &iced::advanced::widget::Tree,
+        layout: iced::advanced::Layout<'_>,
+        cursor: iced::advanced::mouse::Cursor,
+        viewport: &iced::Rectangle,
+        renderer: &Renderer,
+    ) -> iced::advanced::mouse::Interaction {
+        self.content
+            .as_widget()
+            .mouse_interaction(state, layout, cursor, viewport, renderer)
+    }
+
+    fn operate(
+        &self,
+        state: &mut iced::advanced::widget::Tree,
+        layout: iced::advanced::Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn iced::advanced::widget::Operation<()>,
+    ) {
+        operation.container(None, layout.bounds(), &mut |operation| {
+            self.content
+                .as_widget()
+                .operate(&mut state.children[0], layout, renderer, operation);
+        })
+    }
+
+    fn state(&self) -> iced::advanced::widget::tree::State {
+        iced::advanced::widget::tree::State::None
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut iced::advanced::widget::Tree,
+        layout: iced::advanced::Layout<'_>,
+        renderer: &Renderer,
+        translation: iced::Vector,
+    ) -> Option<iced::advanced::overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content
+            .as_widget_mut()
+            .overlay(&mut tree.children[0], layout, renderer, translation)
+    }
+
+    fn layout(
+        &self,
+        tree: &mut iced::advanced::widget::Tree,
+        renderer: &Renderer,
+        limits: &iced::advanced::layout::Limits,
+    ) -> iced::advanced::layout::Node {
+        self.content
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits)
+    }
+
+    fn draw(
+        &self,
+        tree: &iced::advanced::widget::Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &iced::advanced::renderer::Style,
+        layout: iced::advanced::Layout<'_>,
+        cursor: iced::advanced::mouse::Cursor,
+        viewport: &iced::Rectangle,
+    ) {
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            viewport,
+        )
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut iced::advanced::widget::Tree,
+        event: iced::Event,
+        layout: iced::advanced::Layout<'_>,
+        cursor: iced::advanced::mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn iced::advanced::Clipboard,
+        shell: &mut iced::advanced::Shell<'_, Message>,
+        viewport: &iced::Rectangle,
+    ) -> iced::advanced::graphics::core::event::Status {
+        let status = self.content.as_widget_mut().on_event(
+            &mut tree.children[0],
+            event.clone(),
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+
+        if !self.spring.has_energy() {
+            return status;
+        }
+
+        if let Some(on_update) = &self.on_update {
+            let now = Instant::now();
+            shell.publish(on_update(now));
+        }
+
+        status
+    }
+}
+
+impl<'a, T, Message, Theme, Renderer> From<Animation<'a, T, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    T: 'static + Animate,
+    Message: 'a + Clone,
+    Theme: 'a,
+    Renderer: iced::advanced::Renderer + 'a,
+{
+    fn from(animation: Animation<'a, T, Message, Theme, Renderer>) -> Self {
+        Self::new(animation)
+    }
+}

--- a/animation_builder/src/animation_builder.rs
+++ b/animation_builder/src/animation_builder.rs
@@ -237,7 +237,7 @@ where
             }
 
             // Update the animation and request a redraw
-            spring.update(now);
+            spring.tick(now);
             self.cached_element = (self.builder)(spring.value().clone());
 
             // TODO: Figure out why uncommenting this fixes the `nested_animations` example

--- a/animation_builder/src/lib.rs
+++ b/animation_builder/src/lib.rs
@@ -97,12 +97,14 @@ pub mod animate;
 pub mod animation;
 pub mod animation_builder;
 pub mod spring;
+pub mod spring_event;
 pub mod spring_motion;
 
 pub use animate::Animate;
 pub use animation::Animation;
 pub use animation_builder::*;
 pub use spring::Spring;
+pub use spring_event::SpringEvent;
 pub use spring_motion::SpringMotion;
 
 #[cfg(feature = "derive")]

--- a/animation_builder/src/lib.rs
+++ b/animation_builder/src/lib.rs
@@ -94,11 +94,13 @@
 //! app state instead of within the `AnimationBuilder`.
 
 pub mod animate;
+pub mod animation;
 pub mod animation_builder;
 pub mod spring;
 pub mod spring_motion;
 
 pub use animate::Animate;
+pub use animation::Animation;
 pub use animation_builder::*;
 pub use spring::Spring;
 pub use spring_motion::SpringMotion;

--- a/animation_builder/src/spring.rs
+++ b/animation_builder/src/spring.rs
@@ -54,6 +54,14 @@ where
         self.motion = motion;
     }
 
+    /// Updates the spring's `target` to the given value, resetting the initial distance
+    /// and last update time.
+    pub fn set_target(&mut self, target: T) {
+        self.initial_distance = self.value.distance_to(&target);
+        self.last_update = Instant::now();
+        self.target = target;
+    }
+
     /// Returns an updated spring with the given `motion`.
     pub fn with_motion(mut self, motion: SpringMotion) -> Self {
         self.motion = motion;
@@ -62,9 +70,7 @@ where
 
     /// Returns an updated spring with the given `target`.
     pub fn with_target(mut self, target: T) -> Self {
-        self.initial_distance = self.value.distance_to(&target);
-        self.last_update = Instant::now();
-        self.target = target;
+        self.set_target(target);
         self
     }
 
@@ -171,6 +177,15 @@ where
     }
 }
 
+impl<T> Default for Spring<T>
+where
+    T: Animate + Default,
+{
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,5 +234,12 @@ mod tests {
         // The target should change as well as adjust the last update time.
         assert_eq!(spring.target, 5.0);
         assert!(spring.last_update() > now);
+    }
+
+    /// Springs should implement `Default` if `T` does.
+    #[test]
+    fn default_impl() {
+        let spring = Spring::<f32>::default();
+        assert_eq!(spring.value(), &f32::default());
     }
 }

--- a/animation_builder/src/spring.rs
+++ b/animation_builder/src/spring.rs
@@ -93,6 +93,19 @@ where
     }
 
     /// Updates the spring based on the given `event`.
+    ///
+    /// You can update either the current value by passing `SpringEvent::Tick`
+    /// or change the target value by passing `SpringEvent::Target`.
+    ///
+    /// ```rust
+    /// # use iced_anim::{Spring, SpringEvent};
+    /// let mut spring = Spring::new(0.0);
+    /// spring.update(SpringEvent::Target(5.0));
+    /// assert_eq!(spring.target(), &5.0);
+    ///
+    /// spring.update(SpringEvent::Tick(std::time::Instant::now()));
+    /// assert!(*spring.value() > 0.0);
+    /// ```
     pub fn update(&mut self, event: SpringEvent<T>) {
         match event {
             SpringEvent::Tick(now) => self.tick(now),

--- a/animation_builder/src/spring_event.rs
+++ b/animation_builder/src/spring_event.rs
@@ -8,6 +8,18 @@
 //! You can also use the `From` impl to create a `SpringEvent::Target` from a
 //! value, e.g. `Message::ChangeSize(5.0.into())` instead of
 //! `Message::ChangeSize(SpringEvent::Target(5.0))`.
+//!
+//! ```rust
+//! # use iced_anim::{Spring, SpringEvent};
+//! let mut spring_1 = Spring::new(0.0);
+//! spring_1.update(SpringEvent::Target(5.0));
+//!
+//! let mut spring_2 = Spring::new(0.0);
+//! spring_2.update(5.0.into());
+//!
+//! assert_eq!(spring_1.target(), &5.0);
+//! assert_eq!(spring_2.target(), &5.0);
+//! ```
 use std::time::Instant;
 
 use crate::Animate;

--- a/animation_builder/src/spring_event.rs
+++ b/animation_builder/src/spring_event.rs
@@ -1,0 +1,69 @@
+//! An event associated with an animated `Spring` value.
+//!
+//! Spring events can represent two general types of events:
+//! - A tick event that updates the spring's value
+//! - A target event that sets the spring's target value
+//!
+//! This event can be passed to `Spring::update` to update the spring's value.
+//! You can also use the `From` impl to create a `SpringEvent::Target` from a
+//! value, e.g. `Message::ChangeSize(5.0.into())` instead of
+//! `Message::ChangeSize(SpringEvent::Target(5.0))`.
+use std::time::Instant;
+
+use crate::Animate;
+
+/// An event associated with an animated `Spring` value.
+///
+/// This event represents one of two things:
+/// - A tick event that updates the spring's value, e.g. a frame is rendered
+/// and the spring's value should be updated.
+/// - A target event that sets the spring's target value, e.g. a user presses
+/// a button and changes the target size of an animated value.
+///
+/// This event can be passed to `Spring::update` to update the spring's value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpringEvent<T> {
+    /// A tick event that updates the spring's value, e.g. a frame is rendered
+    /// and the spring's value should be updated.
+    Tick(Instant),
+    /// A target event that sets the spring's target value, e.g. a user presses
+    /// a button and changes the target size of an animated value.
+    Target(T),
+}
+
+// Impl `Copy` for `SpringEvent` when `T` is `Copy`.
+impl<T> Copy for SpringEvent<T> where T: Copy {}
+
+// Any `From` usages should return a `SpringEvent::Target` variant.
+impl<T> From<T> for SpringEvent<T>
+where
+    T: Animate,
+{
+    fn from(value: T) -> Self {
+        SpringEvent::Target(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `from` impl should return a `SpringEvent::Target` variant
+    /// to allow users to do `5.0.into()` to create a `SpringEvent::Target`.
+    ///
+    /// This should slightly reduce the amount of boilerplate needed to
+    /// create a `SpringEvent::Target` from a value.
+    #[test]
+    fn from_impl_sets_target() {
+        let update = SpringEvent::from(5.0);
+        assert!(matches!(update, SpringEvent::Target(5.0)));
+    }
+
+    /// `SpringEvent` should implement `Copy` when `T` does.
+    #[test]
+    fn copy_impl() {
+        let update = SpringEvent::from(5.0);
+        let copy = update;
+        assert_eq!(update, copy);
+    }
+}

--- a/animation_builder_derive/src/lib.rs
+++ b/animation_builder_derive/src/lib.rs
@@ -54,18 +54,17 @@ pub fn animate_derive(input: TokenStream) -> TokenStream {
                 total
             }
 
-            fn update(&mut self, components: &mut impl Iterator<Item = f32>) {
+            fn update(&mut self, components: &mut impl Iterator<Item = ::core::primitive::f32>) {
                 #(#update_fields)*
             }
 
-            fn distance_to(&self, end: &Self) -> Vec<f32> {
-                let mut distances = Vec::with_capacity(Self::components());
+            fn distance_to(&self, end: &Self) -> ::std::vec::Vec<::core::primitive::f32> {
+                let mut distances = ::std::vec::Vec::with_capacity(Self::components());
                 #(#distance_fields)*
                 distances.concat()
             }
         }
     };
 
-    // Convert the generated implementation into a TokenStream and return it
     TokenStream::from(impl_gen)
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -41,3 +41,7 @@ path = "animated_drawer.rs"
 [[example]]
 name = "nested_animations"
 path = "nested_animations.rs"
+
+[[example]]
+name = "stateful_animation"
+path = "stateful_animation.rs"

--- a/examples/animated_theme.rs
+++ b/examples/animated_theme.rs
@@ -27,7 +27,7 @@ impl State {
             &self.theme,
             container(
                 row![
-                    pick_list(Theme::ALL, Some(self.theme.value().clone()), |theme| {
+                    pick_list(Theme::ALL, Some(self.theme.target().clone()), |theme| {
                         Message::ChangeTheme(theme.into())
                     }),
                     palette_grid(self.theme.value().extended_palette()),

--- a/examples/stateful_animation.rs
+++ b/examples/stateful_animation.rs
@@ -1,0 +1,99 @@
+//! An example of a stateful animation using the `Animation` widget instead of
+//! the `AnimationBuilder` widget. Stateful animations store the animation
+//! within the app state whereas the `AnimationBuilder` widget stores the
+//! animation within the widget tree.
+use std::time::{Duration, Instant};
+
+use iced::{
+    widget::{container, mouse_area, Space},
+    Border, Color, Element, Length, Point, Size, Subscription, Theme,
+};
+use iced_anim::{Animation, Spring, SpringMotion};
+
+#[derive(Debug, Clone)]
+enum Message {
+    UpdatePosition(Instant),
+    Target(Point),
+    Resized(u32, u32),
+}
+
+struct State {
+    /// The current position of the bubble in the window.
+    position: Spring<Point>,
+    /// The size of the window to help generate a color.
+    size: Size<u32>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            position: Spring::new(Point::new(50.0, 50.0)).with_motion(SpringMotion::Custom {
+                response: Duration::from_millis(500),
+                damping: 0.6,
+            }),
+            size: Size::new(1024, 768),
+        }
+    }
+}
+
+impl State {
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::Target(position) => self.position.set_target(position),
+            Message::UpdatePosition(now) => self.position.update(now),
+            Message::Resized(width, height) => self.size = Size::new(width, height),
+        }
+    }
+
+    /// Listens for window resize events to ensure the bubble color is accurate.
+    fn subscription(&self) -> Subscription<Message> {
+        iced::event::listen_with(|event, _, _| match event {
+            iced::Event::Window(iced::window::Event::Resized { width, height }) => {
+                Some(Message::Resized(width, height))
+            }
+            _ => None,
+        })
+    }
+
+    fn view(&self) -> Element<Message> {
+        let size = self.size;
+        container(
+            mouse_area(
+                Animation::new(
+                    &self.position,
+                    container(
+                        container(Space::new(Length::Fill, Length::Fill))
+                            .width(self.position.value().x)
+                            .height(self.position.value().y)
+                            .style(move |_: &Theme| container::Style {
+                                border: Border::rounded(8),
+                                background: Some(get_color(self.position.value(), size).into()),
+                                ..Default::default()
+                            }),
+                    )
+                    .fill(),
+                )
+                .on_update(Message::UpdatePosition),
+            )
+            .on_move(Message::Target),
+        )
+        .fill()
+        .into()
+    }
+}
+
+/// Returns a color based on the position and size of the screen.
+fn get_color(position: &Point, size: Size<u32>) -> Color {
+    let width: f32 = (size.width as f32).max(1.0);
+    let height: f32 = (size.height as f32).max(1.0);
+    let x_ratio = position.x / width;
+    let y_ratio = position.y / height;
+
+    Color::from_rgb(x_ratio, y_ratio, 1.0 - x_ratio)
+}
+
+pub fn main() -> iced::Result {
+    iced::application("Stateful Animation", State::update, State::view)
+        .subscription(State::subscription)
+        .run()
+}

--- a/examples/stateful_animation.rs
+++ b/examples/stateful_animation.rs
@@ -2,18 +2,17 @@
 //! the `AnimationBuilder` widget. Stateful animations store the animation
 //! within the app state whereas the `AnimationBuilder` widget stores the
 //! animation within the widget tree.
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use iced::{
     widget::{container, mouse_area, Space},
     Border, Color, Element, Length, Point, Size, Subscription, Theme,
 };
-use iced_anim::{Animation, Spring, SpringMotion};
+use iced_anim::{Animation, Spring, SpringEvent, SpringMotion};
 
 #[derive(Debug, Clone)]
 enum Message {
-    UpdatePosition(Instant),
-    Target(Point),
+    UpdatePosition(SpringEvent<Point>),
     Resized(u32, u32),
 }
 
@@ -39,8 +38,7 @@ impl Default for State {
 impl State {
     fn update(&mut self, message: Message) {
         match message {
-            Message::Target(position) => self.position.set_target(position),
-            Message::UpdatePosition(now) => self.position.update(now),
+            Message::UpdatePosition(event) => self.position.update(event),
             Message::Resized(width, height) => self.size = Size::new(width, height),
         }
     }
@@ -75,7 +73,7 @@ impl State {
                 )
                 .on_update(Message::UpdatePosition),
             )
-            .on_move(Message::Target),
+            .on_move(|point| Message::UpdatePosition(point.into())),
         )
         .fill()
         .into()


### PR DESCRIPTION
This PR adds a new `Animation` widget that powers state-driven animations instead of widget-driven animations like the `AnimationBuilder`. The main difference between this widget and `AnimationBuilder` is that this widget animates a value directly in your app state and enables you to emit a message when something needs to change. This design more easily supports nested animations than the `AnimationBuilder` due to not needing a closure to create a cached element at the cost of having to maintain the animated value directly in your state (which can be a good thing depending on the data).

Three examples now use this widget:

- `stateful_animation` - A new example to showcase the widget.
- `nested_animations` - Updated to show how to this crate supports nested animations
- `animated_theme` - Updated to use the `Animation` widget and remove the unnecessary `themer` widget