### PR TITLE
Only re-render AnimationBuilder on RedrawRequest

### DIFF
--- a/animation_builder/src/animation_builder.rs
+++ b/animation_builder/src/animation_builder.rs
@@ -1,6 +1,4 @@
 //! Implicitly animate between value changes.
-use std::time::Instant;
-
 use iced::{
     advanced::{
         graphics::core::event,
@@ -221,11 +219,10 @@ where
             viewport,
         );
 
-        let now = Instant::now();
+        let iced::Event::Window(iced::window::Event::RedrawRequested(now)) = event else {
+            return status;
+        };
 
-        // TODO: Figure out if there's a way to get `RedrawRequested` working.
-        // It causes animation lag on the `animated_bubble` example due to constant interruptions
-        // leading to a 0ms rebuild time instead of the usual ~8/16 ms for a single frame.
         let spring = tree.state.downcast_mut::<Spring<T>>();
 
         // Request a redraw if the spring has remaining energy
@@ -239,19 +236,6 @@ where
             // Update the animation and request a redraw
             spring.tick(now);
             self.cached_element = (self.builder)(spring.value().clone());
-
-            // TODO: Figure out why uncommenting this fixes the `nested_animations` example
-            // but breaks the `preview_motion` example.
-            // return self.cached_element.as_widget_mut().on_event(
-            //     &mut tree.children[0],
-            //     event,
-            //     layout,
-            //     cursor,
-            //     renderer,
-            //     clipboard,
-            //     shell,
-            //     viewport,
-            // );
         }
 
         status


### PR DESCRIPTION
This PR adjusts the `Spring::interrupt` logic to only reset the last update time when the spring is at rest. This should help avoid constantly updating the `AnimationBuilder`'s spring value since it no longer reacts to all events.

It was previously reacting to all events because the `diff` widget logic was calling `Spring::interrupt` when the value was changed, resetting the last update time. Unfortunately, this reset the last update time right before `on_event` was called, leading to the spring having a near zero time difference for updating the spring instead of the ~8ms that it should be. This caused constantly interrupted animations like the `animated_bubble` to appear to animate in slow motion since the effective `dt` was far smaller than it should have been.