### PR TITLE
Custom themes

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dev-dependencies]
 iced = { workspace = true, features = ["advanced", "debug", "tokio"] }
-iced_anim = { version = "0.1.0", path = "../iced_anim", features = ["derive"] }
+iced_anim = { version = "0.1.0", path = "../iced_anim", features = ["derive", "serde"] }
 
 [[example]]
 name = "animated_color"
@@ -45,3 +45,7 @@ path = "nested_animations.rs"
 [[example]]
 name = "stateful_animation"
 path = "stateful_animation.rs"
+
+[[example]]
+name = "custom_theme"
+path = "custom_theme.rs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dev-dependencies]
 iced = { workspace = true, features = ["advanced", "debug", "tokio"] }
+serde = { version = "1.0", features = ["derive"] }
 iced_anim = { version = "0.1.0", path = "../iced_anim", features = ["derive", "serde"] }
 
 [[example]]

--- a/examples/custom_theme.rs
+++ b/examples/custom_theme.rs
@@ -1,0 +1,159 @@
+use iced::{
+    daemon::DefaultStyle,
+    widget::{button, text},
+    Border, Color, Element,
+};
+use iced_anim::{Animate, Animation, Spring, SpringEvent};
+
+/// A custom theme used by your application that supports a `Custom` theme
+/// to power animations between different variants.
+#[derive(Debug, Clone, Default, PartialEq)]
+enum Theme {
+    #[default]
+    Light,
+    Dark,
+    /// A custom theme with a custom color palette, useful for animations.
+    Custom(Palette),
+}
+
+impl Theme {
+    /// Gets the relevant color palette for the theme.
+    fn palette(&self) -> Palette {
+        match self {
+            Theme::Light => LIGHT_PALETTE,
+            Theme::Dark => DARK_PALETTE,
+            Theme::Custom(palette) => *palette,
+        }
+    }
+}
+
+// Implement `Animate` trait using the `Theme::Custom` variant for animated values.
+impl Animate for Theme {
+    fn components() -> usize {
+        Palette::components()
+    }
+
+    fn distance_to(&self, end: &Self) -> Vec<f32> {
+        self.palette().distance_to(&end.palette())
+    }
+
+    fn update(&mut self, components: &mut impl Iterator<Item = f32>) {
+        let mut palette = self.palette();
+        palette.update(components);
+        *self = Theme::Custom(palette);
+    }
+}
+
+// A default daemon style for the custom theme.
+impl DefaultStyle for Theme {
+    fn default_style(&self) -> iced::daemon::Appearance {
+        let palette = self.palette();
+        iced::daemon::Appearance {
+            text_color: palette.text,
+            background_color: palette.background,
+        }
+    }
+}
+
+// Implement custom catalogs for some widgets to use the custom theme.
+impl button::Catalog for Theme {
+    type Class<'a> = ();
+    fn default<'a>() -> Self::Class<'a> {
+        ()
+    }
+
+    fn style(&self, _class: &Self::Class<'_>, _status: button::Status) -> button::Style {
+        let palette = self.palette();
+        button::Style {
+            text_color: palette.text,
+            background: Some(palette.primary.into()),
+            border: Border::default().rounded(6),
+            ..Default::default()
+        }
+    }
+}
+
+impl text::Catalog for Theme {
+    type Class<'a> = ();
+    fn default<'a>() -> Self::Class<'a> {
+        ()
+    }
+
+    fn style(&self, _class: &Self::Class<'_>) -> text::Style {
+        text::Style {
+            color: Some(self.palette().text),
+        }
+    }
+}
+
+/// A custom color palette used by your application that derives `Animate`.
+/// This palette is what you should use in your custom catalog implementations
+/// because it gets animated when the theme changes.
+#[derive(Debug, Clone, Copy, PartialEq, Animate)]
+struct Palette {
+    background: Color,
+    primary: Color,
+    text: Color,
+}
+
+/// A light theme for your application.
+const LIGHT_PALETTE: Palette = Palette {
+    background: Color::from_rgb(0.9, 0.9, 0.9),
+    primary: Color::from_rgb(0.0, 0.75, 1.0),
+    text: Color::BLACK,
+};
+
+/// A dark theme for your application.
+const DARK_PALETTE: Palette = Palette {
+    background: Color::from_rgb(0.1, 0.1, 0.1),
+    primary: Color::from_rgb(1.0, 0.5, 0.0),
+    text: Color::WHITE,
+};
+
+#[derive(Debug, Clone)]
+enum Message {
+    /// Indicates that the theme should change or is changing.
+    ChangeTheme(SpringEvent<Theme>),
+}
+
+#[derive(Default)]
+struct State {
+    /// The current app theme, which may be an animated value.
+    theme: Spring<Theme>,
+}
+
+impl State {
+    fn theme(&self) -> Theme {
+        self.theme.value().clone()
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::ChangeTheme(event) => self.theme.update(event),
+        }
+    }
+
+    fn view(&self) -> Element<Message, Theme> {
+        Animation::new(
+            &self.theme,
+            button(text("Change theme"))
+                .on_press(Message::ChangeTheme(self.next_theme().into()))
+                .padding(8),
+        )
+        .on_update(Message::ChangeTheme)
+        .into()
+    }
+
+    fn next_theme(&self) -> Theme {
+        match self.theme.target() {
+            Theme::Light => Theme::Dark,
+            _ => Theme::Light,
+        }
+    }
+}
+
+pub fn main() -> iced::Result {
+    iced::application("Custom theme", State::update, State::view)
+        .theme(State::theme)
+        .run()
+}

--- a/examples/custom_theme.rs
+++ b/examples/custom_theme.rs
@@ -1,18 +1,21 @@
+//! An example animating a custom theme palette with serde support.
 use iced::{
     daemon::DefaultStyle,
     widget::{button, text},
     Border, Color, Element,
 };
 use iced_anim::{Animate, Animation, Spring, SpringEvent};
+use serde::{Deserialize, Serialize};
 
 /// A custom theme used by your application that supports a `Custom` theme
 /// to power animations between different variants.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 enum Theme {
     #[default]
     Light,
     Dark,
     /// A custom theme with a custom color palette, useful for animations.
+    #[serde(skip)]
     Custom(Palette),
 }
 
@@ -116,7 +119,7 @@ enum Message {
     ChangeTheme(SpringEvent<Theme>),
 }
 
-#[derive(Default)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 struct State {
     /// The current app theme, which may be an animated value.
     theme: Spring<Theme>,

--- a/iced_anim/Cargo.toml
+++ b/iced_anim/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iced_anim"
 description = "A library for creating animations in Iced"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Brady-Simon/iced_anim"

--- a/iced_anim/Cargo.toml
+++ b/iced_anim/Cargo.toml
@@ -10,6 +10,8 @@ readme = "../README.md"
 [dependencies]
 iced.workspace = true
 iced_anim_derive = { version = "0.1.0", path = "../iced_anim_derive", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 derive = ["iced_anim_derive"]
+serde = ["dep:serde"]

--- a/iced_anim/src/spring.rs
+++ b/iced_anim/src/spring.rs
@@ -12,6 +12,7 @@ pub const ESPILON: f32 = 0.005;
 
 /// A representation of a spring animation that interpolates between values.
 /// You typically won't need to use this directly, but it's used by the `AnimationBuilder`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Spring<T> {
     /// The current value of the spring.
@@ -21,12 +22,15 @@ pub struct Spring<T> {
     /// The type of motion that the spring will follow, which controls damping/stiffness.
     motion: SpringMotion,
     /// The last instant at which this spring's value was updated.
+    #[cfg_attr(feature = "serde", serde(skip, default = "Instant::now"))]
     last_update: Instant,
     /// The current velocity components that make up this spring animation.
+    #[cfg_attr(feature = "serde", serde(skip, default))]
     velocity: Vec<f32>,
     /// The initial distance from the target when the animation was started or interrupted.
     /// This is used to help determine when the spring is near its target and is precomputed
     /// to avoid recalculating it every frame.
+    #[cfg_attr(feature = "serde", serde(skip, default))]
     initial_distance: Vec<f32>,
 }
 

--- a/iced_anim/src/spring_motion.rs
+++ b/iced_anim/src/spring_motion.rs
@@ -2,6 +2,7 @@
 use std::{fmt::Display, time::Duration};
 
 /// The motion associated with a spring animation.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum SpringMotion {
     /// A smooth animation without any overshoot of the target.


### PR DESCRIPTION
Added a `custom_theme` example that shows how to animate custom themes and palettes, alongside some basic Serde support via a new `serde` feature flag.