### PR TITLE
Adjust widget operations

### DIFF
--- a/iced_anim/Cargo.toml
+++ b/iced_anim/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iced_anim"
 description = "A library for creating animations in Iced"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Brady-Simon/iced_anim"
@@ -13,5 +13,5 @@ iced_anim_derive = { version = "0.1.0", path = "../iced_anim_derive", optional =
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
-derive = ["iced_anim_derive"]
+derive = ["dep:iced_anim_derive"]
 serde = ["dep:serde"]

--- a/iced_anim/src/animation.rs
+++ b/iced_anim/src/animation.rs
@@ -128,15 +128,19 @@ where
 
     fn mouse_interaction(
         &self,
-        state: &iced::advanced::widget::Tree,
+        tree: &iced::advanced::widget::Tree,
         layout: iced::advanced::Layout<'_>,
         cursor: iced::advanced::mouse::Cursor,
         viewport: &iced::Rectangle,
         renderer: &Renderer,
     ) -> iced::advanced::mouse::Interaction {
-        self.content
-            .as_widget()
-            .mouse_interaction(state, layout, cursor, viewport, renderer)
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
     }
 
     fn operate(
@@ -148,7 +152,7 @@ where
     ) {
         self.content
             .as_widget()
-            .operate(state, layout, renderer, operation);
+            .operate(&mut state.children[0], layout, renderer, operation);
         // operation.container(None, layout.bounds(), &mut |operation| {
         //     self.content
         //         .as_widget()

--- a/iced_anim/src/animation.rs
+++ b/iced_anim/src/animation.rs
@@ -146,11 +146,14 @@ where
         renderer: &Renderer,
         operation: &mut dyn iced::advanced::widget::Operation<()>,
     ) {
-        operation.container(None, layout.bounds(), &mut |operation| {
-            self.content
-                .as_widget()
-                .operate(&mut state.children[0], layout, renderer, operation);
-        })
+        self.content
+            .as_widget()
+            .operate(state, layout, renderer, operation);
+        // operation.container(None, layout.bounds(), &mut |operation| {
+        //     self.content
+        //         .as_widget()
+        //         .operate(&mut state.children[0], layout, renderer, operation);
+        // })
     }
 
     fn state(&self) -> iced::advanced::widget::tree::State {

--- a/iced_anim/src/animation.rs
+++ b/iced_anim/src/animation.rs
@@ -153,11 +153,6 @@ where
         self.content
             .as_widget()
             .operate(&mut state.children[0], layout, renderer, operation);
-        // operation.container(None, layout.bounds(), &mut |operation| {
-        //     self.content
-        //         .as_widget()
-        //         .operate(&mut state.children[0], layout, renderer, operation);
-        // })
     }
 
     fn state(&self) -> iced::advanced::widget::tree::State {

--- a/iced_anim/src/animation_builder.rs
+++ b/iced_anim/src/animation_builder.rs
@@ -218,14 +218,12 @@ where
         renderer: &Renderer,
         operation: &mut dyn iced::advanced::widget::Operation<()>,
     ) {
-        operation.container(None, layout.bounds(), &mut |operation| {
-            self.cached_element.as_widget().operate(
-                &mut state.children[0],
-                layout,
-                renderer,
-                operation,
-            );
-        })
+        self.cached_element.as_widget().operate(
+            &mut state.children[0],
+            layout,
+            renderer,
+            operation,
+        );
     }
 
     fn overlay<'b>(

--- a/iced_anim/src/spring.rs
+++ b/iced_anim/src/spring.rs
@@ -11,7 +11,9 @@ use crate::{spring_event::SpringEvent, Animate, SpringMotion};
 pub const ESPILON: f32 = 0.005;
 
 /// A representation of a spring animation that interpolates between values.
-/// You typically won't need to use this directly, but it's used by the `AnimationBuilder`.
+///
+/// You can use this alongside the `Animation` widget to animate changes to your UI
+/// by storing the spring in your state and updating it with events.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Spring<T> {


### PR DESCRIPTION
This PR tweaks the `Widget::operate` functions for the `Animation` and `AnimationBuilder` widgets to avoid a panic that can occur with some widgets using operations.