### PR TITLE
Fix overshooting color flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ value from props and allows you to emit a message to update the value.
 Both widgets animate values using spring physics instead of easing functions to
 allow for more natural and interruptible animations.
 
+### Animated widgets
+
+A subset of the standard `iced` widgets are exported under a `widgets` feature
+flag. You can use these as drop-in replacements for the existing widgets:
+
+```rust
+use iced::widget::text;
+use iced_anim::widget::button;
+
+let my_button = button(text("Animated button"))
+    .on_press(Message::DoSomething);
+```
+
 ### `AnimationBuilder` widget
 
 The `AnimationBuilder` widget takes some sort of value that implements 

--- a/iced_anim/src/lib.rs
+++ b/iced_anim/src/lib.rs
@@ -9,9 +9,29 @@
 //! state is always up-to-date with the latest value. Refer to those widget modules for documentation
 //! and the `examples` directory for examples on how to use them.
 //!
-//! You can animate anything that implements `Animate`. A handful of common types already
-//! implement `Animate` like `f32`, `iced::Color`, and `iced::Theme`, with more to come in the
-//! future. You can also derive `Animate` on your own types to animate them as well.
+//! ## Animated widgets
+//!
+//! A subset of the standard `iced` widgets are exported under a `widgets` feature
+//! flag. You can use these as drop-in replacements for the existing widgets:
+//!
+//! ```rust
+//! # #[derive(Clone)] enum Message { DoSomething }
+//! use iced::{Element, widget::text};
+//! use iced_anim::widget::button;
+//!
+//! fn fancy_button<'a>() -> Element<'a, Message> {
+//!     button(text("Animated button"))
+//!         .on_press(Message::DoSomething)
+//!         .into()
+//! }
+//! ```
+//!
+//! ## Animating types
+//!
+//! You can animate anything that implements [`Animate`]. A handful of common types already
+//! implement [`Animate`] like [`f32`], [`iced::Color`], and [`iced::Theme`], with more to come
+//! in the future. You can also derive [`Animate`] on your own types to animate them as well
+//! by enabling the `derive` feature flag and adding `#[derive(Animate)]` to your type:
 //!
 //! ```rust
 //! use iced_anim::Animate;
@@ -24,13 +44,13 @@
 //! }
 //! ```
 //!
-//! # Controlling the spring motion
+//! ## Controlling the spring motion
 //!
-//! The spring motion of an `AnimationBuilder` can be customized. There are a few
-//! defaults like `SpringMotion::Smooth` and `SpringMotion::Bouncy`, but you can
-//! provide a custom response and damping fraction with `SpringMotion::Custom`.
+//! The spring motion of an [`AnimationBuilder`] can be customized. There are a few
+//! defaults like [`SpringMotion::Smooth`] and [`SpringMotion::Bouncy`], but you can
+//! provide a custom response and damping fraction with [`SpringMotion::Custom`].
 //!
-//! # Supported Iced versions
+//! ## Supported Iced versions
 //!
 //! This crate supports Iced 0.13 and newer.
 pub mod animate;

--- a/iced_anim/src/spring.rs
+++ b/iced_anim/src/spring.rs
@@ -68,7 +68,7 @@ impl<T> Spring<T> {
         &self.target
     }
 
-    /// Returns the spring's current `SpringMotion`.
+    /// Returns the spring's current [`SpringMotion`].
     pub fn motion(&self) -> SpringMotion {
         self.motion
     }
@@ -94,7 +94,7 @@ impl<T> Spring<T>
 where
     T: Animate,
 {
-    /// Creates a new `Spring` with the initial `value`.
+    /// Creates a new [`Spring`] with the initial `value`.
     ///
     /// Use the builder methods to customize the spring's behavior and target.
     pub fn new(value: T) -> Self {
@@ -252,6 +252,12 @@ mod tests {
 
     use super::*;
 
+    /// The maximum duration between spring updates should be 100ms.
+    #[test]
+    fn max_duration_time() {
+        assert_eq!(MAX_DURATION, Duration::from_millis(100));
+    }
+
     /// Initial springs should have no energy.
     #[test]
     fn new_springs_have_no_energy() {
@@ -350,7 +356,7 @@ mod tests {
         assert_eq!(spring.velocity, vec![0.0]);
     }
 
-    /// Springs should implement `Default` if `T` does.
+    /// Springs should implement [`Default`] if `T` does.
     #[test]
     fn default_impl() {
         let spring = Spring::<f32>::default();

--- a/iced_anim/src/spring.rs
+++ b/iced_anim/src/spring.rs
@@ -1,5 +1,8 @@
 //! Spring physics to enable natural and interactive animations.
-use std::{fmt::Debug, time::Instant};
+use std::{
+    fmt::Debug,
+    time::{Duration, Instant},
+};
 
 use crate::{spring_event::SpringEvent, Animate, SpringMotion};
 
@@ -10,10 +13,21 @@ use crate::{spring_event::SpringEvent, Animate, SpringMotion};
 /// needlessly when the target is effectively reached.
 pub const ESPILON: f32 = 0.005;
 
+/// The maximum duration between spring updates that is allowed before clamping the time
+/// to avoid large jumps in the spring's value.
+///
+/// This is particularly noticeable when the window loses focus and the app stops receiving
+/// redraws, causing the next update to have a much larger duration than the last one.
+pub const MAX_DURATION: Duration = Duration::from_millis(100);
+
 /// A representation of a spring animation that interpolates between values.
 ///
 /// You can use this alongside the `Animation` widget to animate changes to your UI
 /// by storing the spring in your state and updating it with events.
+///
+/// As this is designed for GUI animations and not general-purpose physics simulations,
+/// it includes some features targeted toward avoiding UI issues like overshooting.
+/// See [`MAX_DURATION`] and [`ESPILON`] for examples of this.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Spring<T> {
@@ -109,8 +123,8 @@ where
 
     /// Updates the spring based on the given `event`.
     ///
-    /// You can update either the current value by passing `SpringEvent::Tick`
-    /// or change the target value by passing `SpringEvent::Target`.
+    /// You can update either the current value by passing [`SpringEvent::Tick`]
+    /// or change the target value by passing [`SpringEvent::Target`].
     ///
     /// ```rust
     /// # use iced_anim::{Spring, SpringEvent};
@@ -141,7 +155,7 @@ where
             return;
         }
 
-        let dt = now.duration_since(self.last_update);
+        let dt = now.duration_since(self.last_update).min(MAX_DURATION);
         self.last_update = now;
 
         // End the animation if the spring is near the target wiht low velocity.

--- a/iced_anim/src/widget.rs
+++ b/iced_anim/src/widget.rs
@@ -15,11 +15,6 @@
 //!   only be an [`iced::Color`] and not an [`iced::Gradient`]. Use default or empty values like
 //!   [`iced::Color::TRANSPARENT`] in place of [`None`] to ensure optional values are animated,
 //!   since [`None`] counts as a different variant.
-//! - Animations may appear jumpy if the user alt-tabs during an animation in a way that causes the
-//!   app to stop receiving redraws. This is a side-effect of animations not yet handling the
-//!   window losing focus, so the instant after the user alt-tabs back to the app will be much
-//!   larger than the last time the app was drawn. This seems solvable, but effort has been going
-//!   to other parts of the library for now.
 //! - You can disable animations by passing a [`SpringMotion`] with a duration of `0.0` to the
 //!   `motion` method, but there may be a more ergonomic way to do this in the future.
 pub mod animated_state;


### PR DESCRIPTION
This PR attempts to fix the color flash that can happen when the `Spring` doesn't get consistent redraws. This can happen if a window loses focus for a while or other widgets intercept the events. These changes enforce a maximum delta time that the `Spring` allows, currently set to 100 ms.

**Before**
<video src="https://github.com/user-attachments/assets/0b9abee4-1ff8-487f-9299-7f086b1f8f5d"></video>


**After**
<video src="https://github.com/user-attachments/assets/a645adb3-e731-408c-9455-a540b51ea056"></video>
