### PR TITLE
Add duration helpers

### DIFF
--- a/examples/animated_canvas.rs
+++ b/examples/animated_canvas.rs
@@ -11,7 +11,6 @@ use iced::{
     Padding, Point, Rectangle, Renderer, Size, Theme,
 };
 use iced_anim::{spring::Motion, Animated, Animation, Event};
-use std::time::Duration;
 
 #[derive(Debug, Clone)]
 enum Message {
@@ -45,10 +44,7 @@ impl Default for AppState {
         ];
         Self {
             hovered_index: 0,
-            animated_selection: Animated::spring(
-                shapes[0],
-                Motion::default().with_duration(Duration::from_millis(300)),
-            ),
+            animated_selection: Animated::new(shapes[0], Motion::default().quick()),
             shapes,
         }
     }

--- a/iced_anim/Cargo.toml
+++ b/iced_anim/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iced_anim"
 description = "A library for creating animations in Iced"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Brady-Simon/iced_anim"

--- a/iced_anim/src/animated.rs
+++ b/iced_anim/src/animated.rs
@@ -61,6 +61,26 @@ where
         self
     }
 
+    /// Sets the duration of the [`Animated`] value to 100ms.
+    pub fn very_quick(self) -> Self {
+        self.with_duration(Duration::from_millis(100))
+    }
+
+    /// Sets the duration of the [`Animated`] value to 200ms.
+    pub fn quick(self) -> Self {
+        self.with_duration(Duration::from_millis(200))
+    }
+
+    /// Sets the duration of the [`Animated`] value to 400ms.
+    pub fn slow(self) -> Self {
+        self.with_duration(Duration::from_millis(400))
+    }
+
+    /// Sets the duration of the [`Animated`] value to 500ms.
+    pub fn very_slow(self) -> Self {
+        self.with_duration(Duration::from_millis(500))
+    }
+
     /// Updates the animation based on some [`Event`] that occurred.
     pub fn update(&mut self, event: Event<T>) {
         match &mut self.animation {

--- a/iced_anim/src/animation_builder.rs
+++ b/iced_anim/src/animation_builder.rs
@@ -173,8 +173,8 @@ struct State<T> {
     mode: Mode,
 }
 
-impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for AnimationBuilder<'a, T, Message, Theme, Renderer>
+impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for AnimationBuilder<'_, T, Message, Theme, Renderer>
 where
     T: 'static + Animate,
     Renderer: iced::advanced::Renderer,

--- a/iced_anim/src/lib.rs
+++ b/iced_anim/src/lib.rs
@@ -69,8 +69,8 @@ pub use animated_state::AnimatedState;
 pub use animation::Animation;
 pub use animation_builder::*;
 pub use event::Event;
-pub use spring::Spring;
-pub use transition::Transition;
+pub use spring::{Motion, Spring};
+pub use transition::{Easing, Transition};
 
 #[cfg(feature = "derive")]
 pub use iced_anim_derive::Animate;

--- a/iced_anim/src/spring/motion.rs
+++ b/iced_anim/src/spring/motion.rs
@@ -42,16 +42,36 @@ impl Motion {
         response: Duration::ZERO,
     };
 
-    /// Create a custom spring motion with the given response `duration`.
+    /// Sets the duration of the [`Motion`] to the given value.
     pub fn with_duration(mut self, duration: Duration) -> Self {
         self.response = duration;
         self
     }
 
-    /// Create a custom spring motion with the given `damping` fraction.
+    /// Sets the damping of the [`Motion`] to the given value.
     pub fn with_damping(mut self, damping: f32) -> Self {
         self.damping = damping;
         self
+    }
+
+    /// Sets the duration of the [`Motion`] value to 100ms.
+    pub fn very_quick(self) -> Self {
+        self.with_duration(Duration::from_millis(100))
+    }
+
+    /// Sets the duration of the [`Motion`] to 200ms.
+    pub fn quick(self) -> Self {
+        self.with_duration(Duration::from_millis(200))
+    }
+
+    /// Sets the duration of the [`Motion`] to 400ms.
+    pub fn slow(self) -> Self {
+        self.with_duration(Duration::from_millis(400))
+    }
+
+    /// Sets the duration of the [`Motion`] to 500ms.
+    pub fn very_slow(self) -> Self {
+        self.with_duration(Duration::from_millis(500))
     }
 
     /// The estimated duration of how long the spring animation.

--- a/iced_anim/src/transition/easing.rs
+++ b/iced_anim/src/transition/easing.rs
@@ -87,6 +87,26 @@ impl Easing {
         self
     }
 
+    /// Sets the duration of the [`Easing`] value to 100ms.
+    pub fn very_quick(self) -> Self {
+        self.with_duration(Duration::from_millis(100))
+    }
+
+    /// Sets the duration of the [`Easing`] to 200ms.
+    pub fn quick(self) -> Self {
+        self.with_duration(Duration::from_millis(200))
+    }
+
+    /// Sets the duration of the [`Easing`] to 400ms.
+    pub fn slow(self) -> Self {
+        self.with_duration(Duration::from_millis(400))
+    }
+
+    /// Sets the duration of the [`Easing`] to 500ms.
+    pub fn very_slow(self) -> Self {
+        self.with_duration(Duration::from_millis(500))
+    }
+
     /// Sets whether the easing is reversible and returns the updated easing.
     ///
     /// Reversible animations will transition the current value along the curve backwards if the


### PR DESCRIPTION
This PR adds duration helpers matching `iced`'s initial animation support.

- `.very_quick()`: 100 ms
- `.quick()`: 200 ms
- `.slow()`: 400 ms
- `.very_slow()`: 500 ms

This PR also re-exports `Easing` and `Motion` from the root of the crate since they're used very often, which should aide discoverability. These changes will be published shortly in v0.2.1.